### PR TITLE
Fix issue where OpenAI API key was not used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
           target: ${{ matrix.target }}
       - run: cargo test --all-features
 
-  integration-test:
+  e2e-tests:
     strategy:
       fail-fast: true
       matrix:
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
         python-version: ["3.10"]
-    name: Integration tests
+    name: E2E tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check-dnc:
-    name: check-dnc
+    name: DNC comments
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,8 +72,8 @@ jobs:
         env:
           OPENAI_API_KEY_E2E: ${{ secrets.OPENAI_API_KEY_E2E }}
 
-  formatting:
-    name: Formatting and linting
+  linting:
+    name: Linting and formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,10 +82,6 @@ jobs:
           components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
-
-  linting:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v4
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,12 @@ jobs:
           pip install -r requirements.txt
       - run: cargo build --release
         name: Build binary
-      - name: Run integration tests
+      - name: Run E2E tests
         run: |
           source venv/bin/activate
           python -m pytest -s
+        env:
+          OPENAI_API_KEY_E2E: ${{ secrets.OPENAI_API_KEY_E2E }}
 
   formatting:
     name: Formatting and linting

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Cargo.lock
 venv
 __pycache__
 .pytest_cache
+
+.env*.local

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest==8.3.1
+python-dotenv==1.0.1

--- a/scripts/dnc.sh
+++ b/scripts/dnc.sh
@@ -7,14 +7,18 @@ ROOT_DIR=$(realpath $SCRIPT_DIR/..)
 
 files_to_check=$(git ls-files)
 
+found_dnc=false
+
 for file in $files_to_check; do
-	if [[ $file == *"dnc.sh" ]]; then
+	if [[ $file == *"dnc.sh" || $file == *".github/workflows/"* ]]; then
 		continue
 	fi
 
 	file_path="$ROOT_DIR/$file"
-	bad_command=$(rg -C3 "DNC(\(.*\))*:?\s" $file_path)
+	bad_command=$(rg -C3 "(DNC|dnc)(\(.*\))*:?\s?" $file_path)
 	if [ -n "$bad_command" ]; then
+		found_dnc=true
+
 		echo "Found DNC comment!"
 		echo
 
@@ -23,6 +27,9 @@ for file in $files_to_check; do
 
 		echo "MATCH:"
 		echo "$bad_command"
-		exit 1
 	fi
 done
+
+if [ "$found_dnc" = true ]; then
+	exit 1
+fi

--- a/src/cli/config/mcli_config.rs
+++ b/src/cli/config/mcli_config.rs
@@ -202,9 +202,13 @@ impl MagicCliConfig {
                 let Some(embedding_model) = openai_config.embedding_model.clone() else {
                     return Err(MagicCliConfigError::MissingConfigKey("embedding_model".to_owned()));
                 };
+                let Some(api_key) = openai_config.api_key.clone() else {
+                    return Err(MagicCliConfigError::MissingConfigKey("api_key".to_owned()));
+                };
                 let openai = OpenAiBuilder::new()
                     .with_model(model)
                     .with_embeddings_model(embedding_model)
+                    .with_api_key(api_key)
                     .try_build()
                     .map_err(|e| MagicCliConfigError::Configuration(e.to_string()))?;
                 Ok(Box::new(openai))

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1,26 +1,44 @@
 import tempfile
-from tests.utils import run_subcommand, set_config
+
+import pytest
+from tests.utils import Env, run_subcommand, set_config
 
 
 class TestSuggestSubcommand:
-    # NOTE: Skipping this test for now since SLMs provide a lot of flaky tests.
+    def test_basic_openai(self):
+        env = Env.from_env()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+            with open(tmp.name, "w") as f:
+                f.write('{"llm": "openai"}')
+            set_config("llm", "openai", config_path=tmp.name)
+            set_config("openai.model", "gpt-4o-mini", config_path=tmp.name)
+            set_config("openai.api_key", env.openai_api_key, config_path=tmp.name)
+
+            results = run_subcommand(
+                "suggest", ["'Print the current directory using ls. Use only ls'", "--output-only"], mcli_args=["--config", tmp.name]
+            )
+            assert results.status == 0
+            assert "ls" in results.stdout
+
     # TODO: Test with larger foundation models.
-    # def test_basic_ollama(self):
-    #     with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
-    #         with open(tmp.name, "w") as f:
-    #             f.write("{}")
+    @pytest.mark.skip(reason="Skipping this test for now since SLMs provide a lot of flaky tests.")
+    def test_basic_ollama(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+            with open(tmp.name, "w") as f:
+                f.write("{}")
 
-    #         set_config("llm", "ollama", config_path=tmp.name)
-    #         set_config("ollama.model", "llama3", config_path=tmp.name)
+            set_config("llm", "ollama", config_path=tmp.name)
+            set_config("ollama.model", "llama3", config_path=tmp.name)
 
-    #         with open(tmp.name, "r") as f:
-    #             print(f.read())
+            with open(tmp.name, "r") as f:
+                print(f.read())
 
-    #         results = run_subcommand(
-    #             "suggest", ["'Print the current directory using `ls`. Use only `ls`'", "--output-only"], mcli_args=["--config", tmp.name]
-    #         )
-    #         assert results.status == 0, "Suggest subcommand failed with status code {}".format(results.status)
-    #         assert "ls" in results.stdout, "Suggest subcommand did not return the expected command"
+            results = run_subcommand(
+                "suggest", ["'Print the current directory using `ls`. Use only `ls`'", "--output-only"], mcli_args=["--config", tmp.name]
+            )
+            assert results.status == 0, "Suggest subcommand failed with status code {}".format(results.status)
+            assert "ls" in results.stdout, "Suggest subcommand did not return the expected command"
 
     def test_fail_if_llm_misconfigured(self):
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:


### PR DESCRIPTION
This PR fixes an issue where the OpenAI API key defined in the configuration was not used. I believe this regression was introduced in #27.

## Detailed Changes

- Added back the Open AI key from the configuration in `mcli_config.rs`
- Added a regression test
- Changed logs in tests so that the API key won't be printed

---

Resolves #29 