### PR TITLE
Disallow shell history embedding unless explicitly configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .pytest_cache
 
 .env*.local
+temp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ repository = "https://github.com/guywaldman/magic-cli"
 edition = "2021"
 
 [dependencies]
-orch = { version = "0.0.14" }
-orch_response = { version = "0.0.14" }                 # Will be bundled inside `orch` (#10)
+# DNC
+orch = { version = "0.0.15" }
+orch_response = { version = "0.0.15" }                 # Will be bundled inside `orch` (#10)
 chrono = "0.4.38"
 clap = { version = "4.5.7", features = ["derive"] }
 clipboard = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,8 @@ repository = "https://github.com/guywaldman/magic-cli"
 edition = "2021"
 
 [dependencies]
-orch = { version = "0.0.13" }
-# Note: This is currently a dependency which could be inside `orch` (see https://github.com/guywaldman/orch/issues/10).
-orch_response = { version = "0.0.13" }
+orch = { version = "0.0.14" }
+orch_response = { version = "0.0.14" }                 # Will be bundled inside `orch` (#10)
 chrono = "0.4.38"
 clap = { version = "4.5.7", features = ["derive"] }
 clipboard = "0.5.0"

--- a/src/cli/config/general_config.rs
+++ b/src/cli/config/general_config.rs
@@ -1,0 +1,39 @@
+use orch::lm::LanguageModelProvider;
+use serde::{Deserialize, Serialize};
+
+use super::{ConfigOptions, MagicCliConfigError};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneralConfig {
+    /// The LLM provider to use for generating responses.
+    pub llm: Option<LanguageModelProvider>,
+
+    /// Whether to allow access to the shell history.
+    pub access_to_shell_history: Option<bool>,
+}
+
+impl Default for GeneralConfig {
+    fn default() -> Self {
+        Self {
+            llm: Some(LanguageModelProvider::Ollama),
+            access_to_shell_history: Some(true),
+        }
+    }
+}
+
+impl ConfigOptions for GeneralConfig {
+    fn populate_defaults(&mut self) -> Result<bool, MagicCliConfigError> {
+        let mut populated = false;
+        let defaults = GeneralConfig::default();
+
+        if self.llm.is_none() {
+            populated = true;
+            self.llm = defaults.llm;
+        }
+        if self.access_to_shell_history.is_none() {
+            populated = true;
+            self.access_to_shell_history = defaults.access_to_shell_history;
+        }
+        Ok(populated)
+    }
+}

--- a/src/cli/config/mcli_config.rs
+++ b/src/cli/config/mcli_config.rs
@@ -17,13 +17,22 @@ use super::ConfigKeys;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MagicCliConfigOptions {
+    /// The LLM provider to use for generating responses.
+    pub llm: Option<LanguageModelProvider>,
+
+    /// Configuration for command suggestions (e.g., the `suggest` subcommand).
+    pub suggest: Option<SuggestConfig>,
+
+    /// Configuration for embeddings generation (e.g., in the `search` subcommand).
+    pub embeddings: Option<EmbeddingsConfig>,
+
+    /// Options for the Ollama LLM provider.
     #[serde(rename = "ollama")]
     pub ollama_config: Option<OllamaConfig>,
 
+    /// Options for the OpenAI LLM provider.
     #[serde(rename = "openai")]
     pub openai_config: Option<OpenAiConfig>,
-    pub llm: Option<LanguageModelProvider>,
-    pub suggest: Option<SuggestConfig>,
 }
 
 impl Default for MagicCliConfigOptions {
@@ -44,13 +53,13 @@ impl Display for MagicCliConfigOptions {
 }
 
 #[derive(Debug, Clone)]
-pub struct MagicCliConfig {
+pub struct MagicCliConfigManager {
     /// The path to the configuration file.
     /// The default is used (`~/.config/magic_cli/config.json`) if this is `None`.
     pub config_path: Option<PathBuf>,
 }
 
-impl MagicCliConfig {
+impl MagicCliConfigManager {
     pub fn new(config_path: Option<PathBuf>) -> Self {
         Self { config_path }
     }

--- a/src/cli/config/mod.rs
+++ b/src/cli/config/mod.rs
@@ -1,7 +1,9 @@
+mod general_config;
 mod keys;
 mod mcli_config;
 mod models;
 
+pub use general_config::*;
 pub use keys::*;
 pub use mcli_config::*;
 pub use models::*;

--- a/src/cli/config/models.rs
+++ b/src/cli/config/models.rs
@@ -29,3 +29,9 @@ pub enum MagicCliConfigError {
     #[error("Error converting from or to 'SuggestMode': {0}")]
     SuggestModeError(#[from] SuggestModeError),
 }
+
+pub(crate) trait ConfigOptions {
+    /// Populates the default values for the configuration options.
+    /// Returns `true` if the configuration was populated, `false` if it was already populated.
+    fn populate_defaults(&mut self) -> Result<bool, MagicCliConfigError>;
+}

--- a/src/cli/mcli.rs
+++ b/src/cli/mcli.rs
@@ -1,5 +1,5 @@
 use super::{
-    config::MagicCliConfig,
+    config::MagicCliConfigManager,
     subcommand::{MagicCliRunOptions, MagicCliSubcommand},
     subcommand_ask::AskSubcommand,
     subcommand_config::{ConfigSubcommand, ConfigSubcommands},
@@ -71,7 +71,7 @@ impl MagicCli {
             config,
         } = clap_cli;
 
-        let config = MagicCliConfig::new(config);
+        let config = MagicCliConfigManager::new(config);
         config.initialize_config()?;
 
         match subcommand {
@@ -95,7 +95,7 @@ impl MagicCli {
         Ok(())
     }
 
-    async fn run_subcommmand(config: &MagicCliConfig, subcommand: impl MagicCliSubcommand) {
+    async fn run_subcommmand(config: &MagicCliConfigManager, subcommand: impl MagicCliSubcommand) {
         let run_options = MagicCliRunOptions { config: config.clone() };
         match subcommand.run(run_options).await {
             Ok(_) => {}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,5 @@
 mod command;
-mod config;
+pub(crate) mod config;
 mod mcli;
 mod search;
 mod subcommand;

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -9,7 +9,7 @@ use crate::core::{
     HayStackItem, IndexEngine, IndexError, IndexMetadata, SemanticSearchEngine, SemanticSearchEngineError, Shell, ShellError,
 };
 
-use super::config::{MagicCliConfig, MagicCliConfigError};
+use super::config::{MagicCliConfigManager, MagicCliConfigError};
 
 #[derive(Debug, Error)]
 pub(crate) enum CliSearchError {
@@ -39,7 +39,7 @@ impl CliSearch {
     }
 
     pub async fn search_command(&self, prompt: &str, index: bool) -> Result<String, CliSearchError> {
-        let index_dir_path = MagicCliConfig::get_config_default_dir_path()?.join("index");
+        let index_dir_path = MagicCliConfigManager::get_config_default_dir_path()?.join("index");
         if !index_dir_path.exists() {
             std::fs::create_dir_all(&index_dir_path).unwrap();
         }

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -2,14 +2,18 @@ use chrono::Duration;
 use colored::Colorize;
 use inquire::{list_option::ListOption, InquireError, Select};
 use orch::lm::LanguageModel;
-use std::{collections::HashSet, time::SystemTime};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
 use thiserror::Error;
 
 use crate::core::{
     HayStackItem, IndexEngine, IndexError, IndexMetadata, SemanticSearchEngine, SemanticSearchEngineError, Shell, ShellError,
 };
 
-use super::config::{MagicCliConfigManager, MagicCliConfigError};
+use super::config::{MagicCliConfigError, MagicCliConfigManager};
 
 #[derive(Debug, Error)]
 pub(crate) enum CliSearchError {
@@ -27,10 +31,25 @@ pub(crate) enum CliSearchError {
 
     #[error("Command not selected: {0}")]
     CommandNotSelected(#[from] InquireError),
+
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("No results found")]
+    NoResultsFound,
 }
 
 pub(crate) struct CliSearch {
     lm: Box<dyn LanguageModel>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchOptions {
+    pub index: bool,
+    pub reset_index: bool,
+    pub index_dir_path: PathBuf,
+    pub shell_history_path: PathBuf,
+    pub output_only: bool,
 }
 
 impl CliSearch {
@@ -38,33 +57,97 @@ impl CliSearch {
         Self { lm: llm }
     }
 
-    pub async fn search_command(&self, prompt: &str, index: bool) -> Result<String, CliSearchError> {
-        let index_dir_path = MagicCliConfigManager::get_config_default_dir_path()?.join("index");
-        if !index_dir_path.exists() {
-            std::fs::create_dir_all(&index_dir_path).unwrap();
+    pub async fn search_command(&self, prompt: &str, options: &SearchOptions) -> Result<Option<String>, CliSearchError> {
+        let SearchOptions {
+            index,
+            reset_index,
+            index_dir_path,
+            shell_history_path,
+            output_only,
+        } = options.clone();
+
+        if reset_index {
+            if !output_only {
+                println!("{}", "Resetting index...".yellow());
+            }
+            self.reset_index(&index_dir_path)?;
+            if !output_only {
+                println!("{}", "Index reset successfully.".green());
+            }
         }
-        let index_path = index_dir_path.join("index.json");
-        let index_metadata_path = index_dir_path.join("index_metadata.json");
+
+        if index {
+            // Index shell history if needed and `index` is set to true.
+            self.index_shell_history(&shell_history_path, &index_dir_path, output_only).await?;
+        }
+
+        let index_path = Self::index_path(&index_dir_path)?;
+        let index_metadata_path = Self::index_metadata_path(&index_dir_path)?;
+
+        let index_engine = IndexEngine::new(
+            SemanticSearchEngine::new(dyn_clone::clone_box(&*self.lm)),
+            index_path,
+            index_metadata_path,
+        );
+
+        let index = index_engine.load_index()?;
+        let semantic_search_engine = SemanticSearchEngine::new(dyn_clone::clone_box(&*self.lm));
+        let semantic_search_results = semantic_search_engine.top_k(prompt, index, 10).await?;
+
+        if semantic_search_results.is_empty() && !output_only {
+            println!("{}", "No relevant results found.".yellow().bold());
+            return Ok(None);
+        }
+
+        let options = semantic_search_results
+            .iter()
+            .map(|result| ListOption::new(result.id, result.data.clone()))
+            .collect::<Vec<_>>();
+        if output_only {
+            // In "output only" mode, skip the interactive prompts and simply print the command.
+            let Some(top_result) = semantic_search_results.first() else {
+                return Err(CliSearchError::NoResultsFound);
+            };
+            return Ok(Some(top_result.data.clone()));
+        }
+
+        let selected_command = Select::new(
+            "Select a command:",
+            options,
+            // &semantic_search_results.iter().map(|result| result.data.clone()).collect::<Vec<_>>(),
+        )
+        .prompt();
+
+        selected_command
+            .map(|op| Some(op.to_string()))
+            .map_err(CliSearchError::CommandNotSelected)
+    }
+
+    async fn index_shell_history(&self, shell_history_path: &Path, index_dir_path: &Path, output_only: bool) -> Result<(), CliSearchError> {
+        let index_path = Self::index_path(index_dir_path)?;
+        let index_metadata_path = Self::index_metadata_path(index_dir_path)?;
+
         let index_engine = IndexEngine::new(
             SemanticSearchEngine::new(dyn_clone::clone_box(&*self.lm)),
             index_path,
             index_metadata_path,
         );
         let index_metadata = index_engine.load_index_metadata()?;
-        let should_update_index = index
-            || match index_metadata {
-                IndexMetadata {
-                    last_index_time: Some(last_index_time),
-                } => {
-                    let now = SystemTime::now();
-                    let duration = now.duration_since(last_index_time).unwrap();
-                    duration.as_secs() > Duration::hours(24).num_seconds() as u64
-                }
-                IndexMetadata { last_index_time: None } => true,
-            };
+        let should_update_index = match index_metadata {
+            IndexMetadata {
+                last_index_time: Some(last_index_time),
+            } => {
+                let now = SystemTime::now();
+                let duration = now.duration_since(last_index_time).unwrap();
+                duration.as_secs() > Duration::hours(24).num_seconds() as u64
+            }
+            IndexMetadata { last_index_time: None } => true,
+        };
         if should_update_index {
-            println!("{}", "Updating index (this may take a few moments)...".yellow());
-            let shell_history = Shell::get_shell_history()?;
+            if !output_only {
+                println!("{}", "Updating index (this may take a few moments)...".yellow());
+            }
+            let shell_history = Shell::get_shell_history(shell_history_path)?;
             let mut hay_stack_map = HashSet::new();
             for item in shell_history.iter() {
                 if !hay_stack_map.contains(item) {
@@ -77,30 +160,36 @@ impl CliSearch {
                 .map(|(i, item)| HayStackItem { id: i, data: item.clone() })
                 .collect();
             index_engine.store_index(hay_stack).await?;
-            println!("{}", "Index updated successfully.".green());
+            if !output_only {
+                println!("{}", "Index updated successfully.".green());
+            }
         }
+        Ok(())
+    }
 
-        let index = index_engine.load_index()?;
-        let semantic_search_engine = SemanticSearchEngine::new(dyn_clone::clone_box(&*self.lm));
-        let semantic_search_results = semantic_search_engine.top_k(prompt, index, 10).await?;
+    fn reset_index(&self, index_dir_path: &Path) -> Result<(), CliSearchError> {
+        let index_path = Self::index_path(index_dir_path)?;
+        let index_metadata_path = Self::index_metadata_path(index_dir_path)?;
+        std::fs::remove_file(index_path).map_err(CliSearchError::IoError)?;
+        std::fs::remove_file(index_metadata_path).map_err(CliSearchError::IoError)?;
+        Ok(())
+    }
 
-        if semantic_search_results.is_empty() {
-            println!("{}", "No relevant results found.".yellow().bold());
+    pub fn default_index_dir_path() -> Result<PathBuf, CliSearchError> {
+        let index_dir_path = MagicCliConfigManager::get_config_default_dir_path()?.join("index");
+        if !index_dir_path.exists() {
+            std::fs::create_dir_all(&index_dir_path).unwrap();
         }
+        Ok(index_dir_path)
+    }
 
-        let options = semantic_search_results
-            .iter()
-            .map(|result| ListOption::new(result.id, result.data.clone()))
-            .collect::<Vec<_>>();
-        let selected_command = Select::new(
-            "Select a command:",
-            options,
-            // &semantic_search_results.iter().map(|result| result.data.clone()).collect::<Vec<_>>(),
-        )
-        .prompt();
+    fn index_path(index_dir_path: &Path) -> Result<PathBuf, CliSearchError> {
+        let index_path = index_dir_path.join("index.json");
+        Ok(index_path)
+    }
 
-        selected_command
-            .map(|op| op.to_string())
-            .map_err(CliSearchError::CommandNotSelected)
+    fn index_metadata_path(index_dir_path: &Path) -> Result<PathBuf, CliSearchError> {
+        let index_metadata_path = index_dir_path.join("index_metadata.json");
+        Ok(index_metadata_path)
     }
 }

--- a/src/cli/subcommand.rs
+++ b/src/cli/subcommand.rs
@@ -2,11 +2,11 @@ use std::error::Error;
 
 use async_trait::async_trait;
 
-use super::config::MagicCliConfig;
+use super::config::MagicCliConfigManager;
 
 #[derive(Debug, Clone)]
 pub struct MagicCliRunOptions {
-    pub config: MagicCliConfig,
+    pub config: MagicCliConfigManager,
 }
 
 #[async_trait]

--- a/src/cli/subcommand_ask.rs
+++ b/src/cli/subcommand_ask.rs
@@ -47,9 +47,9 @@ impl AskSubcommand {
 #[async_trait]
 impl MagicCliSubcommand for AskSubcommand {
     async fn run(&self, options: MagicCliRunOptions) -> Result<(), Box<dyn Error>> {
-        let config = &options.config;
-        let config_values = config.load_config()?;
-        let lm = config.lm_from_config()?;
+        let config_mgr = &options.config;
+        let lm = config_mgr.lm_from_config()?;
+        let config = config_mgr.config.clone();
         println!("{}", "Model details:".dimmed());
         println!("{}", format!("  - Language model provider: {}", &lm.provider()).dimmed());
         println!(
@@ -72,7 +72,7 @@ impl MagicCliSubcommand for AskSubcommand {
                     break;
                 }
                 AskResponseOption::Suggestion(ref suggest_response) => {
-                    let Some(config_values) = config_values.suggest.clone() else {
+                    let Some(config_values) = config.suggest.clone() else {
                         return Err(Box::new(MagicCliConfigError::MissingConfigKey("suggest".to_string())));
                     };
                     let command_run_result = CliCommand::new(config_values).suggest_user_action_on_command(&suggest_response.command)?;
@@ -87,7 +87,7 @@ impl MagicCliSubcommand for AskSubcommand {
                         .await?;
                 }
                 AskResponseOption::Ask(ask_response) => {
-                    let Some(config_values) = config_values.suggest.clone() else {
+                    let Some(config_values) = config.suggest.clone() else {
                         return Err(Box::new(MagicCliConfigError::MissingConfigKey("suggest".to_string())));
                     };
                     let command_run_result = CliCommand::new(config_values).suggest_user_action_on_command(&ask_response.command)?;

--- a/src/cli/subcommand_config.rs
+++ b/src/cli/subcommand_config.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use inquire::Text;
 
 use super::{
-    config::{ConfigKeys, MagicCliConfig},
+    config::{ConfigKeys, MagicCliConfigManager},
     subcommand::{MagicCliRunOptions, MagicCliSubcommand},
 };
 
@@ -54,7 +54,7 @@ impl MagicCliSubcommand for ConfigSubcommand {
             ConfigSubcommands::Set { key, value } => {
                 let key = match key {
                     Some(key) => key.to_string(),
-                    None => MagicCliConfig::select_key()?,
+                    None => MagicCliConfigManager::select_key()?,
                 };
                 let value = match value {
                     Some(value) => value.to_string(),
@@ -73,7 +73,7 @@ impl MagicCliSubcommand for ConfigSubcommand {
             ConfigSubcommands::Get { key } => {
                 let key = match key {
                     Some(key) => key.to_string(),
-                    None => MagicCliConfig::select_key()?,
+                    None => MagicCliConfigManager::select_key()?,
                 };
                 match config.get(&key) {
                     Ok(value) => println!("{}", value),
@@ -110,11 +110,11 @@ impl MagicCliSubcommand for ConfigSubcommand {
             }
 
             ConfigSubcommands::Reset => {
-                MagicCliConfig::reset()?;
+                MagicCliConfigManager::reset()?;
                 println!("{}", "Configuration reset to default values.".green().bold());
             }
             ConfigSubcommands::Path => {
-                let default_config_path = MagicCliConfig::get_default_config_file_path()?;
+                let default_config_path = MagicCliConfigManager::get_default_config_file_path()?;
                 println!("{}", default_config_path.display());
             }
         }

--- a/src/cli/subcommand_search.rs
+++ b/src/cli/subcommand_search.rs
@@ -1,37 +1,132 @@
-use std::error::Error;
+use std::{error::Error, path::PathBuf};
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::core::Shell;
 
 use super::{
     command::CliCommand,
-    config::MagicCliConfigError,
-    search::CliSearch,
+    config::{ConfigOptions, MagicCliConfigError},
+    search::{CliSearch, SearchOptions},
     subcommand::{MagicCliRunOptions, MagicCliSubcommand},
 };
 
-pub struct SearchSubcommand {
-    prompt: String,
-    index: bool,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchConfig {
+    /// Whether to allow remote LLMs to embed shell history.
+    pub allow_remote_llm: Option<bool>,
+
+    /// Optional path to the shell history file, otherwise uses the default according to the user's system.
+    pub shell_history: Option<PathBuf>,
+
+    /// Optional path to the index directory, otherwise uses the default according to the user's system.
+    pub index_dir: Option<PathBuf>,
 }
 
-impl SearchSubcommand {
-    pub fn new(prompt: String, index: bool) -> Self {
-        Self { prompt, index }
+impl ConfigOptions for SearchConfig {
+    fn populate_defaults(&mut self) -> Result<bool, MagicCliConfigError> {
+        let mut populated = false;
+        let defaults = SearchConfig::default();
+
+        if self.allow_remote_llm.is_none() {
+            populated = true;
+            self.allow_remote_llm = defaults.allow_remote_llm;
+        }
+        Ok(populated)
     }
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            allow_remote_llm: Some(false),
+            shell_history: None,
+            index_dir: None,
+        }
+    }
+}
+
+pub struct SearchSubcommand {
+    pub prompt: String,
+    pub index: bool,
+    pub reset_index: bool,
+    pub output_only: bool,
 }
 
 #[async_trait]
 impl MagicCliSubcommand for SearchSubcommand {
     async fn run(&self, options: MagicCliRunOptions) -> Result<(), Box<dyn Error>> {
-        let config = options.config;
-        let lm = config.lm_from_config()?;
+        let config_mgr = &options.config;
+        let config = &config_mgr.config;
+
+        // Guard gainst using remote LLMs for embedding shell history.
+        let Some(general_config) = config.general.clone() else {
+            return Err(Box::new(MagicCliConfigError::MissingConfigKey("general".to_string())));
+        };
+        let Some(llm) = general_config.llm else {
+            return Err(Box::new(MagicCliConfigError::MissingConfigKey("general.llm".to_string())));
+        };
+        if !llm.is_local() {
+            let Some(search_config) = config.search.clone() else {
+                return Err(Box::new(MagicCliConfigError::MissingConfigKey("search".to_string())));
+            };
+            let Some(allow_remote_llm) = search_config.allow_remote_llm else {
+                return Err(Box::new(MagicCliConfigError::MissingConfigKey(
+                    "search.allow_remote_llm".to_string(),
+                )));
+            };
+            if !allow_remote_llm {
+                return Err(Box::new(MagicCliConfigError::Configuration(
+                    "Using remote LLM but `allow_remote_llm` is set to false. Set it to `true` if you are willing for remote LLM providers such as OpenAI to embed your shell history which may contains sensitive information.".to_string(),
+                )));
+            }
+        }
+
+        let lm = config_mgr.lm_from_config()?;
         let cli_search = CliSearch::new(dyn_clone::clone_box(&*lm));
-        let selected_command = cli_search.search_command(&self.prompt, self.index).await?;
-        let config_values = config.load_config()?;
-        let Some(suggest_config) = config_values.suggest.clone() else {
+        let Some(search_config) = config.search.clone() else {
+            return Err(Box::new(MagicCliConfigError::MissingConfigKey("search".to_string())));
+        };
+        let shell_history_path = search_config
+            .shell_history
+            .unwrap_or_else(|| Shell::shell_history_path(None).unwrap());
+        let index_dir_path = search_config
+            .index_dir
+            .unwrap_or_else(|| CliSearch::default_index_dir_path().unwrap());
+        let search_options = SearchOptions {
+            index: self.index,
+            reset_index: self.reset_index,
+            shell_history_path,
+            index_dir_path,
+            output_only: self.output_only,
+        };
+        let selected_command = cli_search.search_command(&self.prompt, &search_options).await;
+        let selected_command = match selected_command {
+            Ok(selected_command) => selected_command,
+            Err(err) => {
+                return Err(Box::new(err));
+            }
+        };
+
+        if self.output_only {
+            // In "output only" mode, skip the interactive prompts and simply print the command.
+            if let Some(selected_command) = selected_command {
+                println!("{}", selected_command);
+            }
+            return Ok(());
+        }
+
+        let Some(selected_command) = selected_command else {
+            return Ok(());
+        };
+
+        let Some(suggest_config) = config.suggest.clone() else {
             return Err(Box::new(MagicCliConfigError::MissingConfigKey("suggest".to_string())));
         };
+
         CliCommand::new(suggest_config).suggest_user_action_on_command(&selected_command)?;
+
         Ok(())
     }
 }

--- a/src/cli/subcommand_suggest.rs
+++ b/src/cli/subcommand_suggest.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::core::SuggestionEngine;
 
@@ -9,6 +10,14 @@ use super::{
     config::MagicCliConfigError,
     subcommand::{MagicCliRunOptions, MagicCliSubcommand},
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SuggestMode {
+    #[serde(rename = "clipboard")]
+    Clipboard,
+    #[serde(rename = "unsafe-execution")]
+    Execution,
+}
 
 pub struct SuggestSubcommandArguments {
     pub prompt: String,
@@ -28,12 +37,14 @@ impl SuggestSubcommand {
 #[async_trait]
 impl MagicCliSubcommand for SuggestSubcommand {
     async fn run(&self, options: MagicCliRunOptions) -> Result<(), Box<dyn Error>> {
+        let config_mgr = &options.config;
+        let config = &config_mgr.config;
+
         let lm = options.config.lm_from_config()?;
         let explain_subcommand = SuggestionEngine::new(lm.as_ref());
         let command = explain_subcommand.suggest_command(&self.args.prompt, self.args.output_only).await?;
         if !self.args.output_only {
-            let config_values = options.config.load_config()?;
-            let Some(suggest_config) = config_values.suggest.clone() else {
+            let Some(suggest_config) = config.suggest.clone() else {
                 return Err(Box::new(MagicCliConfigError::MissingConfigKey("suggest".to_string())));
             };
             CliCommand::new(suggest_config).suggest_user_action_on_command(&command)?;

--- a/src/core/semantic_search.rs
+++ b/src/core/semantic_search.rs
@@ -27,8 +27,8 @@ pub struct HayStackItem {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexItem {
-    item: HayStackItem,
-    embedding: Vec<f32>,
+    pub item: HayStackItem,
+    pub embedding: Vec<f32>,
 }
 
 pub struct SemanticSearchEngine {
@@ -36,7 +36,7 @@ pub struct SemanticSearchEngine {
 }
 
 impl SemanticSearchEngine {
-    const SIMILARITY_THRESHOLD: f64 = 0.2;
+    const SIMILARITY_THRESHOLD: f64 = 0.7;
 
     pub fn new(lm: Box<dyn LanguageModel>) -> Self {
         Self {
@@ -57,7 +57,7 @@ impl SemanticSearchEngine {
             .filter_map(|item| {
                 let similarity = f32::cosine(item.embedding.as_slice(), needle_embedding.as_slice());
 
-                if similarity.map(|score| score < Self::SIMILARITY_THRESHOLD).unwrap_or(false) {
+                if similarity.map(|score| score > Self::SIMILARITY_THRESHOLD).unwrap_or(false) {
                     return None;
                 }
 

--- a/src/core/suggestion.rs
+++ b/src/core/suggestion.rs
@@ -76,7 +76,10 @@ pub struct SuggestResponseError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SuggestConfig {
+    /// The mode to use for suggesting commands. Supported values: "clipboard" (copying command to clipboard), "unsafe-execution" (executing in the current shell session).
     pub mode: Option<SuggestMode>,
+
+    /// Whether to add the suggested command to the shell history.
     pub add_to_history: Option<bool>,
 }
 

--- a/src/core/suggestion.rs
+++ b/src/core/suggestion.rs
@@ -8,7 +8,10 @@ use orch::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::core::Shell;
+use crate::{
+    cli::config::{ConfigOptions, MagicCliConfigError},
+    core::Shell,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SuggestMode {
@@ -89,6 +92,22 @@ impl Default for SuggestConfig {
             mode: Some(SuggestMode::Execution),
             add_to_history: Some(false),
         }
+    }
+}
+
+impl ConfigOptions for SuggestConfig {
+    fn populate_defaults(&mut self) -> Result<bool, MagicCliConfigError> {
+        let mut populated = false;
+        let defaults = SuggestConfig::default();
+        if self.mode.is_none() {
+            populated = true;
+            self.mode = defaults.mode;
+        }
+        if self.add_to_history.is_none() {
+            populated = true;
+            self.add_to_history = defaults.add_to_history;
+        }
+        Ok(populated)
     }
 }
 

--- a/src/lm/ollama_config.rs
+++ b/src/lm/ollama_config.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::cli::config::{ConfigOptions, MagicCliConfigError};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OllamaConfig {
     pub base_url: Option<String>,
@@ -14,5 +16,26 @@ impl Default for OllamaConfig {
             model: Some("codestral:latest".to_string()),
             embedding_model: Some("nomic-embed-text:latest".to_string()),
         }
+    }
+}
+
+impl ConfigOptions for OllamaConfig {
+    fn populate_defaults(&mut self) -> Result<bool, MagicCliConfigError> {
+        let mut populated = false;
+        let defaults = OllamaConfig::default();
+
+        if self.base_url.is_none() {
+            populated = true;
+            self.base_url = defaults.base_url;
+        }
+        if self.model.is_none() {
+            populated = true;
+            self.model = defaults.model;
+        }
+        if self.embedding_model.is_none() {
+            populated = true;
+            self.embedding_model = defaults.embedding_model;
+        }
+        Ok(populated)
     }
 }

--- a/src/lm/openai_config.rs
+++ b/src/lm/openai_config.rs
@@ -1,6 +1,8 @@
 use orch::lm::{openai_embedding_model, openai_model};
 use serde::{Deserialize, Serialize};
 
+use crate::cli::config::{ConfigOptions, MagicCliConfigError};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenAiConfig {
     pub api_key: Option<String>,
@@ -15,5 +17,27 @@ impl Default for OpenAiConfig {
             model: Some(openai_model::GPT_4O_MINI.to_string()),
             embedding_model: Some(openai_embedding_model::TEXT_EMBEDDING_ADA_002.to_string()),
         }
+    }
+}
+
+impl ConfigOptions for OpenAiConfig {
+    fn populate_defaults(&mut self) -> Result<bool, MagicCliConfigError> {
+        let mut populated = false;
+
+        let defaults = OpenAiConfig::default();
+        if self.api_key.is_none() {
+            populated = true;
+            self.api_key = defaults.api_key;
+        }
+        if self.model.is_none() {
+            populated = true;
+            self.model = defaults.model;
+        }
+        if self.embedding_model.is_none() {
+            populated = true;
+            self.embedding_model = defaults.embedding_model;
+        }
+
+        Ok(populated)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.run(&args).await {
         Ok(_) => {}
         Err(err) => {
-            eprintln!("ERROR: {}", format!("Error: {}", err).red().bold());
+            eprintln!("{}", format!("ERROR: {}", err).red().bold());
             std::process::exit(1);
         }
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,36 +1,70 @@
+import json
 import tempfile
 from tests.utils import run_subcommand
 
 
 class TestConfig:
+    def test_config_populate_defaults(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+            with open(tmp.name, "w") as f:
+                f.write("{}")
+
+            results = run_subcommand("config", ["get", "general.llm"], mcli_args=["--config", f.name])
+            assert results.status == 0
+            assert "ollama" in results.stdout
+
+            results = run_subcommand("config", ["get", "suggest.mode"], mcli_args=["--config", f.name])
+            assert results.status == 0
+            assert "unsafe-execution" in results.stdout
+
+            results = run_subcommand("config", ["get", "suggest.add_to_history"], mcli_args=["--config", f.name])
+            assert results.status == 0
+            assert "false" in results.stdout
+
+    def test_config_reset(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+            with open(tmp.name, "w") as f:
+                f.write(json.dumps({"general": {"llm": "openai"}}))
+
+            results = run_subcommand("config", ["get", "general.llm"], mcli_args=["--config", f.name])
+            assert results.status == 0
+            assert "openai" in results.stdout
+
+            results = run_subcommand("config", ["reset"], mcli_args=["--config", f.name])
+            assert results.status == 0
+
+            results = run_subcommand("config", ["get", "general.llm"], mcli_args=["--config", f.name])
+            assert results.status == 0
+            assert "ollama" in results.stdout
+
     def test_custom_config_get(self):
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
             with open(tmp.name, "w") as f:
-                f.write('{"llm": "ollama"}')
+                f.write(json.dumps({"general": {"llm": "ollama"}}))
 
             with open(tmp.name, "r") as f:
-                results = run_subcommand("config", ["get", "llm"], mcli_args=["--config", f.name])
+                results = run_subcommand("config", ["get", "general.llm"], mcli_args=["--config", f.name])
                 assert results.status == 0
                 assert "ollama" in results.stdout
 
             with open(tmp.name, "w") as f:
-                f.write('{"llm": "openai"}')
+                f.write(json.dumps({"general": {"llm": "openai"}}))
 
             with open(tmp.name, "r") as f:
-                results = run_subcommand("config", ["get", "llm"], mcli_args=["--config", f.name])
+                results = run_subcommand("config", ["get", "general.llm"], mcli_args=["--config", f.name])
                 assert results.status == 0
                 assert "openai" in results.stdout
 
     def test_custom_config_set(self):
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
             with open(tmp.name, "w") as f:
-                f.write('{"llm": "ollama"}')
+                f.write(json.dumps({"general": {"llm": "ollama"}}))
 
             with open(tmp.name, "r") as f:
-                results = run_subcommand("config", ["set", "--key", "llm", "--value", "openai"], mcli_args=["--config", f.name])
+                results = run_subcommand("config", ["set", "--key", "general.llm", "--value", "openai"], mcli_args=["--config", f.name])
                 assert results.status == 0
 
             with open(tmp.name, "r") as f:
-                results = run_subcommand("config", ["get", "llm"], mcli_args=["--config", f.name])
+                results = run_subcommand("config", ["get", "general.llm"], mcli_args=["--config", f.name])
                 assert results.status == 0
                 assert "openai" in results.stdout

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,49 @@
+import json
+import tempfile
+
+from tests.utils import Env, run_subcommand, set_config
+
+
+class TestSearchSubcommand:
+    """Tests for the `search` subcommand, which allows users to semantically search for commands across their shell history."""
+
+    def test_basic_search_openai(self):
+        env = Env.from_env()
+
+        with tempfile.TemporaryDirectory() as index_dir, tempfile.NamedTemporaryFile(
+            mode="w", delete=False
+        ) as config, tempfile.NamedTemporaryFile(mode="w", delete=False) as shell_history:
+            with open(config.name, "w") as f:
+                f.write(json.dumps({"general": {"llm": "openai"}, "search": {"shell_history": shell_history.name, "index_dir": index_dir}}))
+
+            with open(shell_history.name, "w") as f:
+                f.write("echo foobar\n")
+                f.write("echo lorem ipsum\n")
+
+            set_config("openai.model", "gpt-4o-mini", config_path=config.name)
+            set_config("openai.embedding_model", "text-embedding-ada-002", config_path=config.name)
+            set_config("openai.api_key", env.openai_api_key, config_path=config.name)
+
+            results = run_subcommand("search", ["foobar", "--output-only"], mcli_args=["--config", config.name])
+            assert results.status == 0
+            assert "echo foobar" in results.stdout
+
+    def test_search_with_remote_llm(self):
+        env = Env.from_env()
+
+        with tempfile.TemporaryDirectory() as index_dir, tempfile.NamedTemporaryFile(
+            mode="w", delete=False
+        ) as config, tempfile.NamedTemporaryFile(mode="w", delete=False) as shell_history:
+            with open(config.name, "w") as f:
+                f.write(json.dumps({"general": {"llm": "openai"}, "search": {"shell_history": shell_history.name, "index_dir": index_dir}}))
+
+            with open(shell_history.name, "w") as f:
+                f.write("echo foobar\n")
+                f.write("echo lorem ipsum\n")
+
+            set_config("openai.model", "gpt-4o-mini", config_path=config.name)
+            set_config("openai.embedding_model", "text-embedding-ada-002", config_path=config.name)
+            set_config("openai.api_key", env.openai_api_key, config_path=config.name)
+
+            results = run_subcommand("search", ["foobar", "--output-only"], mcli_args=["--config", config.name])
+            print(results)

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 
 import pytest
@@ -5,13 +6,16 @@ from tests.utils import Env, run_subcommand, set_config
 
 
 class TestSuggestSubcommand:
+    """Tests for the `suggest` subcommand, which allows users to suggest commands based on their prompt."""
+
     def test_basic_openai(self):
         env = Env.from_env()
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
             with open(tmp.name, "w") as f:
-                f.write('{"llm": "openai"}')
-            set_config("llm", "openai", config_path=tmp.name)
+                f.write(json.dumps({"general": {"llm": "openai"}}))
+
+            set_config("general.llm", "openai", config_path=tmp.name)
             set_config("openai.model", "gpt-4o-mini", config_path=tmp.name)
             set_config("openai.api_key", env.openai_api_key, config_path=tmp.name)
 
@@ -28,7 +32,7 @@ class TestSuggestSubcommand:
             with open(tmp.name, "w") as f:
                 f.write("{}")
 
-            set_config("llm", "ollama", config_path=tmp.name)
+            set_config("general.llm", "ollama", config_path=tmp.name)
             set_config("ollama.model", "llama3", config_path=tmp.name)
 
             with open(tmp.name, "r") as f:
@@ -45,7 +49,7 @@ class TestSuggestSubcommand:
             with open(tmp.name, "w") as f:
                 f.write("{}")
 
-            set_config("llm", "openai", config_path=tmp.name)
+            set_config("general.llm", "openai", config_path=tmp.name)
             results = run_subcommand(
                 "suggest", ["'Print the current directory using `ls`. Use only `ls`'"], mcli_args=["--config", tmp.name]
             )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import subprocess
 import dotenv
 
 
-def run_subcommand(subcommand: str, subcommand_args: list[str], mcli_args: list[str] = []):
+def run_subcommand(subcommand: str, subcommand_args: list[str] = [], log_args: bool = False, mcli_args: list[str] = []):
     """Helper utility which runs the subcommand with the given arguments and returns the results."""
 
     root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -12,12 +12,14 @@ def run_subcommand(subcommand: str, subcommand_args: list[str], mcli_args: list[
 
     command = f"{magic_cli_executable_path} {' '.join(mcli_args)} {subcommand} {' '.join(subcommand_args)}"
 
-    print(f"Running subcommand '{subcommand}'...")
+    command_log = command if log_args else f"{magic_cli_executable_path} (...arguments omitted...)"
+
+    print(f"Running command '{command_log}'...")
     proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
     stdout, stderr, status = proc.stdout, proc.stderr, proc.returncode
 
-    print(f"Finished running subcommand '{subcommand}' with status code {status}")
+    print(f"Finished running command '{command_log}' with status code {status}")
 
     return RunResults(
         stdout=stdout.decode("utf-8"),
@@ -26,9 +28,15 @@ def run_subcommand(subcommand: str, subcommand_args: list[str], mcli_args: list[
     )
 
 
-def set_config(key: str, value: str, config_path: str | None = None):
+def run_shell_command(command: str, log_args: bool = False, args: list[str] = []):
+    """Helper utility which runs a shell command and returns the results."""
+
+    print(f"Running shell command '{command}'...")
+
+
+def set_config(key: str, value: str, log_args: bool = False, config_path: str | None = None):
     mcli_args = [] if config_path is None else ["--config", config_path]
-    results = run_subcommand("config", ["set", "--key", key, "--value", value], mcli_args=mcli_args)
+    results = run_subcommand("config", ["set", "--key", key, "--value", value], log_args=log_args, mcli_args=mcli_args)
     assert results.status == 0
 
 


### PR DESCRIPTION
This PR:
- Adds a new `general.access_to_shell_history` configuration flag for explicitly allowing access to shell history
- Adds a new `search.allow_remote_llm` configuration flag for explicitly allowing access to shell history to non-local LLM providers
- Adds a new `search.shell_history` configuration for specifying a custom path to a shell history file (added for testing, but may be optionally useful for users none the less)
- Adds a new `search.index_dir` configuration for specifying a custom path to a directory which will contain the indexing data and metadata (added for testing, but may be optionally useful for users none the less)
- Adds and improves on E2E test coverage

Addresses #30 