### PR TITLE
Add support for customizing OpenAI endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run E2E tests
         run: ./scripts/e2e-tests.sh
         env:
-          OPENAI_API_KEY_E2E: ${{ secrets.OPENAI_API_KEY_E2E }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_E2E }}
 
   linting:
     name: Linting and formatting

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__
 
 .env*.local
 temp
+
+# macOS
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ repository = "https://github.com/guywaldman/magic-cli"
 edition = "2021"
 
 [dependencies]
-orch = { version = "0.0.15" }
-orch_response = { version = "0.0.15" }                 # Will be bundled inside `orch` (#10)
+orch = { version = "0.0.16" }
+orch_response = { version = "0.0.16" }                 # Will be bundled inside `orch` (#10)
 chrono = "0.4.38"
 clap = { version = "4.5.7", features = ["derive"] }
 clipboard = "0.5.0"

--- a/src/cli/config/keys.rs
+++ b/src/cli/config/keys.rs
@@ -193,6 +193,20 @@ impl ConfigKeys {
                 ).secret()
             );
             keys.insert(
+                "openai.api_endpoint".to_string(),
+                ConfigurationKey::new(
+                    "openai.api_endpoint".to_string(),
+                    "Custom API endpoint for the OpenAI API.".to_string(),
+                    Box::new(|config: &mut MagicCliConfig, value: &str| {
+                        if config.openai_config.is_none() {
+                            config.openai_config = Some(OpenAiConfig::default());
+                        }
+                        config.openai_config.as_mut().unwrap().api_endpoint = Some(value.to_string());
+                        Ok(())
+                    }),
+                ).secret()
+            );
+            keys.insert(
                 "openai.model".to_string(),
                 ConfigurationKey::new(
                     "openai.model".to_string(),

--- a/src/cli/config/mcli_config.rs
+++ b/src/cli/config/mcli_config.rs
@@ -237,14 +237,19 @@ impl MagicCliConfigManager {
                 let Some(api_key) = openai_config.api_key.clone() else {
                     return Err(MagicCliConfigError::MissingConfigKey("api_key".to_owned()));
                 };
-                let openai = OpenAiBuilder::new()
+                let mut openai_builder = OpenAiBuilder::new()
                     .with_model(model)
                     .with_embeddings_model(embedding_model)
-                    .with_api_key(api_key)
+                    .with_api_key(api_key);
+                if let Some(api_endpoint) = openai_config.api_endpoint.clone() {
+                    openai_builder = openai_builder.with_api_endpoint(api_endpoint);
+                }
+                let openai = openai_builder
                     .try_build()
                     .map_err(|e| MagicCliConfigError::Configuration(e.to_string()))?;
                 Ok(Box::new(openai))
             }
+            _ => Err(MagicCliConfigError::Configuration("Invalid LLM provider".to_string())),
         }
     }
 

--- a/src/cli/subcommand_search.rs
+++ b/src/cli/subcommand_search.rs
@@ -78,7 +78,7 @@ impl MagicCliSubcommand for SearchSubcommand {
             };
             if !allow_remote_llm {
                 return Err(Box::new(MagicCliConfigError::Configuration(
-                    "Using remote LLM but `allow_remote_llm` is set to false. Set it to `true` if you are willing for remote LLM providers such as OpenAI to embed your shell history which may contains sensitive information.".to_string(),
+                    "Using remote LLM but `search.allow_remote_llm` is set to false. Set it to `true` if you are willing for remote LLM providers such as OpenAI to embed your shell history which may contains sensitive information.".to_string(),
                 )));
             }
         }

--- a/src/lm/openai_config.rs
+++ b/src/lm/openai_config.rs
@@ -6,6 +6,7 @@ use crate::cli::config::{ConfigOptions, MagicCliConfigError};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenAiConfig {
     pub api_key: Option<String>,
+    pub api_endpoint: Option<String>,
     pub model: Option<String>,
     pub embedding_model: Option<String>,
 }
@@ -14,6 +15,7 @@ impl Default for OpenAiConfig {
     fn default() -> Self {
         Self {
             api_key: None,
+            api_endpoint: None,
             model: Some(openai_model::GPT_4O_MINI.to_string()),
             embedding_model: Some(openai_embedding_model::TEXT_EMBEDDING_ADA_002.to_string()),
         }
@@ -28,6 +30,10 @@ impl ConfigOptions for OpenAiConfig {
         if self.api_key.is_none() {
             populated = true;
             self.api_key = defaults.api_key;
+        }
+        if self.api_endpoint.is_none() {
+            populated = true;
+            self.api_endpoint = defaults.api_endpoint;
         }
         if self.model.is_none() {
             populated = true;

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,8 +61,8 @@ class Env:
             print(f"Loading environment variables from '{env_path}'")
             dotenv.load_dotenv(dotenv_path=env_path)
 
-        openai_api_key = os.environ.get("OPENAI_API_KEY_E2E")
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
         if openai_api_key is None:
-            raise Exception("OPENAI_API_KEY_E2E environment variable not set")
+            raise Exception("OPENAI_API_KEY environment variable not set")
 
         return cls(openai_api_key=openai_api_key)


### PR DESCRIPTION
This PR adds support for customizing the OpenAI endpoint with a new `openai.api_endpoint` configuration key.

Addresses #28 